### PR TITLE
Refactor(Maintenance): Updates the route to retrieve status from public API and adjusts the object dereference path

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repo holds the status pages when the web app (cea-desktop) is down.
 
 Both pages are hosted on an S3 bucket: https://us-east-1.console.aws.amazon.com/s3/buckets/cea-error-pages
 
-These pages retrieve data from the status.io API to display on the page. The credential to the Text-Em-All status.io account can be found [on the engineering wiki](https://sites.google.com/call-em-all.com/engineeringoperationswiki/contact-info?authuser=0#h.p_2_vfmYqglTNj).
+These pages retrieve data from the status.io [public status API](https://status.text-em-all.com/1.0/status/536bd6f1fd254d6008000273) to display on the page. The credential to the Text-Em-All status.io account can be found [on the engineering wiki](https://sites.google.com/call-em-all.com/engineeringoperationswiki/contact-info?authuser=0#h.p_2_vfmYqglTNj).
 
 ## How to Update the Contents of the Error or Maintenance Pages
 
@@ -26,4 +26,5 @@ Please follow these instructions carefully to ensure the update is done correctl
 - [Guide to updating status.io messages (Incidents vs Maintenance)](https://docs.google.com/document/d/1wp1BLBJq0KWVw31sUlQ7hVIxYAyFJxTIOBCybZ_h1AE/edit?tab=t.0)
 - [Status.io](https://status.io/)
 - [Status.io credentials](https://sites.google.com/call-em-all.com/engineeringoperationswiki/contact-info?authuser=0#h.p_2_vfmYqglTNj)
+- [Public Status API](https://status.text-em-all.com/1.0/status/536bd6f1fd254d6008000273)
 - [Text-Em-All status page](https://status.text-em-all.com/)

--- a/maintenance.html
+++ b/maintenance.html
@@ -252,17 +252,17 @@
  ></script>
     <script type="text/javascript">
       $(function () {
-        $.get('https://maintenance.herokuapp.com/status', function (data) {
+        $.get('https://status.text-em-all.com/1.0/status/536bd6f1fd254d6008000273', function (data) {
           console.log(data.result);
-          if (data.result.active_maintenances[0]) {
+          if (data.result.maintenance.active[0]) {
             $('#planned-end-date').html(
               moment(
-                data.result.active_maintenances[0].datetime_planned_end
+                data.result.maintenance.active[0].datetime_planned_end
               ).format('MMMM Do, YYYY h:mm a')
             );
 
             $('#status-date').html(
-              moment(data.result.active_maintenances[0].datetime_open).format('MMMM Do, YYYY h:mm a')
+              moment(data.result.maintenance.active[0].datetime_open).format('MMMM Do, YYYY h:mm a')
             );
           }
         });


### PR DESCRIPTION
# Partially Completes [Trello Story](https://trello.com/c/t8YCGD90/2772-maintenance-page-relies-on-abandoned-project-to-get-data-from-statusio)

## What does this PR accomplish?
- Eliminates dependency on outdated Node.js application for querying status data from status.io.
- Leverages the publicly accessible API provided by status.io to retrieve status information.
- Updates the object dereference path to align with the structure of the `status` endpoint, replacing the previously used protected `maintenance/list` endpoint.

### Reference:
[Status Endpoint Documentation](https://statusio.docs.apiary.io/#reference/metrics/update-metric/status/summary)