### PR TITLE
Refactor(error.html): Retrieves status info from publicly accessible API instead of bifrost

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,5 @@ Please follow these instructions carefully to ensure the update is done correctl
 - [Guide to updating status.io messages (Incidents vs Maintenance)](https://docs.google.com/document/d/1wp1BLBJq0KWVw31sUlQ7hVIxYAyFJxTIOBCybZ_h1AE/edit?tab=t.0)
 - [Status.io](https://status.io/)
 - [Status.io credentials](https://sites.google.com/call-em-all.com/engineeringoperationswiki/contact-info?authuser=0#h.p_2_vfmYqglTNj)
-- [Public Status API](https://status.text-em-all.com/1.0/status/536bd6f1fd254d6008000273)
+- [Status.io Public Status API](https://status.text-em-all.com/1.0/status/536bd6f1fd254d6008000273)
 - [Text-Em-All status page](https://status.text-em-all.com/)

--- a/error.html
+++ b/error.html
@@ -257,15 +257,19 @@
    <script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.6/moment.min.js"></script>
     <script type="text/javascript">
-      $.get('https://bifrost.call-em-all.com/system_status', function (data) {
+      $.get('https://status.text-em-all.com/1.0/status/536bd6f1fd254d6008000273', function (data) {
+        var incidentData = data.result.incidents;
+        var latestIncident = incidentData[incidentData.length - 1];
+        var latestIncidentMessage = latestIncident?.messages[latestIncident.messages.length - 1]
         $('#status-message').html(
-          data.details ||
+          latestIncidentMessage?.details ||
             'We’re currently experiencing a service interruption, but our team is working hard to resolve it as soon as possible. Thank you for your patience and understanding!'
         );
 
-        if (data.datetime)
+        var statusDate = latestIncidentMessage?.datetime;
+        if (statusDate)
           $('#status-date').html(
-            moment(data.datetime).format('MMMM Do, YYYY h:mm a')
+            moment(statusDate).format('MMMM Do, YYYY h:mm a')
           );
         else $('#last-update').hide();
       });


### PR DESCRIPTION
# Completes [Trello Story](https://trello.com/c/t8YCGD90/2772-maintenance-page-relies-on-abandoned-project-to-get-data-from-statusio)

## What does this PR accomplish?
- Gets status info from status.io instead of Bifrost.
- Updates the object dereference path to align with the structure of the `status` endpoint as specified in the [staus.io docs](https://statusio.docs.apiary.io/#reference/maintenance/get-maintenance/status/summary).
- Updates bullet point in readme.

### Reference:
[Status Endpoint Documentation](https://statusio.docs.apiary.io/#reference/metrics/update-metric/status/summary)